### PR TITLE
mt_rand is 4 times faster

### DIFF
--- a/loops/php/code.php
+++ b/loops/php/code.php
@@ -4,7 +4,7 @@ $u = (int) $argv[1];                                # Get an input number from t
 
 function main(int $u)
 {
-    $r = rand(0, 10000);                                # Get a random number 0 <= r < 10k
+    $r = mt_rand(0, 10000);                                # Get a random number 0 <= r < 10k
     $a = array_fill(0, 10000, 0);    # Array of 10k elements initialized to 0
     for ($i = 0; $i < 10000; $i++) {                    # 10k outer loop iterations
         for ($j = 0; $j < 100000; $j++) {               # 100k inner loop iterations, per outer loop iteration

--- a/loops/php/code.php
+++ b/loops/php/code.php
@@ -5,7 +5,7 @@ $u = (int) $argv[1];                                # Get an input number from t
 function main(int $u)
 {
     $r = mt_rand(0, 10000);                                # Get a random number 0 <= r < 10k
-    $a = array_fill(0, 10000, 0);    # Array of 10k elements initialized to 0
+    $a = new SplFixedArray(10000);             # Array of 10k elements initialized to 0
     for ($i = 0; $i < 10000; $i++) {                    # 10k outer loop iterations
         for ($j = 0; $j < 100000; $j++) {               # 100k inner loop iterations, per outer loop iteration
             $a[$i] += $j%$u;                    # Simple sum


### PR DESCRIPTION
As the bench measure all the time (create array, loop, ...) need to be faster.

<!-- Thanks for helping to improve this project! 🙏 -->

I have:

* [x] Read the project [README](../../blob/main/README.md), including the [benchmark descriptions](../../blob/main/README.md#available-benchmarks)
* [x] Read the PR template instructions before I deleted them
* [x] Understood that if I have changed something that could impact performance of one or more contributions, I should provide results benchmark runs, using the `run.sh` script, from before and after the change.

## Description of changes

<!-- 

Please include a descrition for your change. Things like:

* Why it is done (a problem description)
  If there's an issue describing the problem, please refer it. If your PR is fixing the problem described in the issue, use the _Fixes #<issue-no>_  syntax.
* Why it is done the way you have done it (a solution description)

Please help us understand the changes and the rationale even if we are not experts or even familiar with the particular language you are providing changes for.

If you provide changes to the implementation of one or more language, for one or more benchmark, please include output from benchmark runs, using run.sh, from before and after the change. (TIPS: You can use a copy of run.sh to avoid running the benchmarks for other languages.) Please provide the results as text rather than as screen dumps.

Thanks again for contributing!
-->

